### PR TITLE
Fix a crash when an inverse property is not a list

### DIFF
--- a/lib/grax/rdf/mapper.ex
+++ b/lib/grax/rdf/mapper.ex
@@ -53,7 +53,7 @@ defmodule Grax.RDF.Mapper do
       description,
       if(additions, do: Graph.add(graph, additions), else: graph)
       |> Graph.add(
-        Enum.map(values, fn value ->
+        Enum.map(List.wrap(values), fn value ->
           {value, property, description.subject}
         end)
       )

--- a/test/grax/rdf/mapper_test.exs
+++ b/test/grax/rdf/mapper_test.exs
@@ -255,6 +255,21 @@ defmodule Grax.RDF.MapperTest do
               |> RDF.graph()}
   end
 
+  test "singular inverse properties" do
+    assert Example.SingularInverseProperties.build!(EX.S,
+             name: "subject",
+             foo: Example.user(EX.User0, depth: 0)
+           )
+           |> to_rdf() ==
+             {:ok,
+              [
+                EX.S |> EX.name("subject"),
+                EX.User0 |> EX.foo(EX.S),
+                example_description(:user)
+              ]
+              |> RDF.graph()}
+  end
+
   test "rdf:type for schema class is defined" do
     assert Example.ClassDeclaration.build!(EX.S, name: "foo")
            |> to_rdf() ==

--- a/test/support/example_schemas.ex
+++ b/test/support/example_schemas.ex
@@ -391,6 +391,15 @@ defmodule Example do
     end
   end
 
+  defmodule SingularInverseProperties do
+    use Grax.Schema
+
+    schema do
+      property name: EX.name()
+      link foo: -EX.foo(), type: Example.User
+    end
+  end
+
   defmodule HeterogeneousLinks do
     use Grax.Schema
 


### PR DESCRIPTION
As of now, when a schema has an inverse property that is not a list, `to_rdf` crashes with a "protocol Enumerable not implemented" exception.

This PR adds a test case that illustrates the issue, and a fix.